### PR TITLE
Report submission

### DIFF
--- a/backend/api/apps.py
+++ b/backend/api/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class ApiConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "api"
+    
+    def ready(self):
+        import api.signals  # noqa

--- a/backend/api/migrations/0005_add_user_report_number.py
+++ b/backend/api/migrations/0005_add_user_report_number.py
@@ -1,0 +1,43 @@
+# Generated manually to add user_report_number field
+
+from django.db import migrations, models
+
+
+def populate_user_report_numbers(apps, schema_editor):
+    """Populate user_report_number for existing reports"""
+    Report = apps.get_model('api', 'Report')
+    
+    # Group reports by user and assign sequential numbers
+    users_reports = {}
+    for report in Report.objects.all().order_by('owner_id', 'created_at'):
+        if report.owner_id not in users_reports:
+            users_reports[report.owner_id] = 1
+        else:
+            users_reports[report.owner_id] += 1
+        
+        report.user_report_number = users_reports[report.owner_id]
+        report.save(update_fields=['user_report_number'])
+
+
+def reverse_populate_user_report_numbers(apps, schema_editor):
+    """Reverse migration - nothing to do since we're removing the field"""
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0004_vsme_register'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='report',
+            name='user_report_number',
+            field=models.PositiveIntegerField(default=1, help_text='Sequential report number per user'),
+        ),
+        migrations.RunPython(
+            populate_user_report_numbers,
+            reverse_populate_user_report_numbers,
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -24,6 +24,7 @@ class Report(models.Model):
     owner = models.ForeignKey(User, on_delete=models.CASCADE, related_name="reports")
     company = models.ForeignKey(Company, on_delete=models.PROTECT, related_name="reports")
     reporting_year = models.PositiveIntegerField()
+    user_report_number = models.PositiveIntegerField(default=1, help_text="Sequential report number per user")
     original_file = models.FileField(upload_to="reports/original/")
     oim_json_file = models.FileField(upload_to="reports/oim/", null=True, blank=True)
 
@@ -50,7 +51,8 @@ class Report(models.Model):
         comp = getattr(self, "company", None)
         cy = f", {self.reporting_year}" if getattr(self, "reporting_year", None) else ""
         cname = f" — {comp.name}" if comp else ""
-        return f"Report #{self.id}{cname}{cy} — {entity} ({period})"
+        report_num = getattr(self, "user_report_number", self.id)
+        return f"Report #{report_num}{cname}{cy} — {entity} ({period})"
 
 
 class Fact(models.Model):

--- a/backend/api/oim.py
+++ b/backend/api/oim.py
@@ -109,3 +109,42 @@ def extract_facts(oim_json: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
     return rows
 
 
+def extract_reporting_year_from_period(reporting_period: str) -> int | None:
+    """Extract a reporting year from a period string like '2024-01-01 to 2024-12-31' or '2024-12-31'."""
+    if not reporting_period:
+        return None
+    
+    import re
+    # Look for 4-digit years in the period string
+    years = re.findall(r'\b(20\d{2}|19\d{2})\b', reporting_period)
+    if years:
+        # Return the last/most recent year found
+        return int(years[-1])
+    return None
+
+
+def quick_extract_metadata_from_file(file_path: str) -> Tuple[str, str, int | None]:
+    """
+    Quick extraction of entity, period, and year from an uploaded file.
+    Returns (entity_name, reporting_period, reporting_year).
+    This is a best-effort approach for pre-processing validation.
+    """
+    try:
+        import tempfile
+        import os
+        import shutil
+        
+        # We'll attempt a simpler approach - try to avoid the full Arelle processing for now
+        # and fallback to a basic filename/content analysis
+        
+        # For now, return empty values to prevent processing errors
+        # The full processing will still extract this information later
+        logger.info("Quick metadata extraction skipped for file: %s", file_path)
+        return "", "", None
+        
+    except Exception as e:
+        logger.warning("Quick metadata extraction failed: %s", e)
+    
+    return "", "", None
+
+

--- a/backend/api/signals.py
+++ b/backend/api/signals.py
@@ -1,0 +1,89 @@
+from django.db.models.signals import post_delete, pre_delete
+from django.dispatch import receiver
+from django.contrib.auth.models import User
+from .models import Report, VsmeRegister
+from .register import recompute_vsme_register
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_delete, sender=Report)
+def cleanup_vsme_register_on_report_delete(sender, instance, **kwargs):
+    """
+    Clean up VsmeRegister entries when a Report is deleted.
+    This handles both direct report deletion and cascade deletion from user deletion.
+    """
+    try:
+        recompute_vsme_register(instance.company_id, instance.reporting_year)
+        logger.info(
+            f"Cleaned up VsmeRegister for company_id={instance.company_id}, year={instance.reporting_year} after report deletion"
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to cleanup VsmeRegister for company_id={instance.company_id}, year={instance.reporting_year}: {e}"
+        )
+
+
+@receiver(post_delete, sender=Report)
+def renumber_user_reports_on_delete(sender, instance, **kwargs):
+    """
+    Renumber remaining reports for the user to maintain sequential numbering.
+    """
+    try:
+        # Get all remaining reports for this user, ordered by creation time
+        remaining_reports = Report.objects.filter(owner=instance.owner).order_by('created_at')
+        
+        # Renumber them sequentially
+        for i, report in enumerate(remaining_reports, 1):
+            if report.user_report_number != i:
+                report.user_report_number = i
+                report.save(update_fields=['user_report_number'])
+        
+        logger.info(f"Renumbered {remaining_reports.count()} reports for user {instance.owner.username}")
+    except Exception as e:
+        logger.error(f"Failed to renumber reports for user {instance.owner.username}: {e}")
+
+
+@receiver(pre_delete, sender=User)
+def cleanup_vsme_register_on_user_delete(sender, instance, **kwargs):
+    """
+    Clean up VsmeRegister entries when a User is deleted.
+    This collects all (company_id, year) pairs from the user's reports before they are cascade deleted.
+    """
+    try:
+        # Collect all (company_id, year) pairs from user's validated reports before cascade deletion
+        company_year_pairs = list(
+            Report.objects.filter(
+                owner=instance, 
+                status=Report.Status.VALIDATED
+            ).values_list('company_id', 'reporting_year').distinct()
+        )
+        
+        # Store them for post-delete cleanup
+        if company_year_pairs:
+            # Use a custom attribute to pass data to post_delete signal
+            instance._vsme_cleanup_pairs = company_year_pairs
+            logger.info(
+                f"Marked {len(company_year_pairs)} company-year pairs for VsmeRegister cleanup after user deletion"
+            )
+    except Exception as e:
+        logger.error(f"Failed to prepare VsmeRegister cleanup for user deletion: {e}")
+
+
+@receiver(post_delete, sender=User)
+def execute_vsme_register_cleanup_on_user_delete(sender, instance, **kwargs):
+    """
+    Execute the VsmeRegister cleanup after user and their reports are deleted.
+    """
+    try:
+        # Get the pairs we stored in pre_delete
+        company_year_pairs = getattr(instance, '_vsme_cleanup_pairs', [])
+        
+        for company_id, year in company_year_pairs:
+            recompute_vsme_register(company_id, year)
+            logger.info(
+                f"Cleaned up VsmeRegister for company_id={company_id}, year={year} after user deletion"
+            )
+    except Exception as e:
+        logger.error(f"Failed to execute VsmeRegister cleanup after user deletion: {e}")

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -34,4 +34,7 @@ urlpatterns = [
     path("vsme-register/export.csv", views.register_export_csv, name="vsme_register_export_csv"),
     path("vsme-register/<int:company_id>/<int:year>/", views.register_detail, name="vsme_register_detail"),
     path("vsme-register/rebuild/", views.register_rebuild, name="vsme_register_rebuild"),
+    path("vsme-register/cleanup-user/", views.register_cleanup_user, name="vsme_register_cleanup_user"),
+    # Insights
+    path("insights/aggregated/", views.insights_aggregated, name="insights_aggregated"),
 ]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -174,12 +174,16 @@ def health(request: Request) -> Response:
 @permission_classes([IsAuthenticated])
 @parser_classes([MultiPartParser, FormParser])
 def report_upload(request: Request) -> Response:
+    logger.info("Report upload request from user: %s", request.user)
+    
     serializer = ReportUploadSerializer(data=request.data, context={"request": request})
     if serializer.is_valid():
         report: Report = serializer.save()
         process_report_async(report.id)
         _maybe_schedule_cleanup()
         return Response({"id": report.id, "status": report.status}, status=201)
+    
+    logger.warning("Serializer validation failed: %s", serializer.errors)
     return Response(serializer.errors, status=400)
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
 				"@eslint/compat": "^1.2.5",
 				"@eslint/js": "^9.18.0",
 				"@sveltejs/adapter-auto": "^6.0.0",
+				"@sveltejs/adapter-node": "^5.2.0",
 				"@sveltejs/kit": "^2.16.0",
 				"@sveltejs/vite-plugin-svelte": "^5.0.0",
 				"@tailwindcss/forms": "^0.5.9",
@@ -806,6 +807,112 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@rollup/plugin-commonjs": {
+			"version": "28.0.6",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.6.tgz",
+			"integrity": "sha512-XSQB1K7FUU5QP+3lOQmVCE3I0FcbbNvmNT4VJSj93iUjayaARrTQeoRdiYQoftAJBLrR9t2agwAd3ekaTgHNlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rollup/pluginutils": "^5.0.1",
+				"commondir": "^1.0.1",
+				"estree-walker": "^2.0.2",
+				"fdir": "^6.2.0",
+				"is-reference": "1.2.1",
+				"magic-string": "^0.30.3",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=16.0.0 || 14 >= 14.17"
+			},
+			"peerDependencies": {
+				"rollup": "^2.68.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rollup/plugin-commonjs/node_modules/is-reference": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+			"integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "*"
+			}
+		},
+		"node_modules/@rollup/plugin-json": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+			"integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rollup/pluginutils": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rollup/plugin-node-resolve": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.1.tgz",
+			"integrity": "sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rollup/pluginutils": "^5.0.1",
+				"@types/resolve": "1.20.2",
+				"deepmerge": "^4.2.2",
+				"is-module": "^1.0.0",
+				"resolve": "^1.22.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^2.78.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rollup/pluginutils": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+			"integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^2.0.2",
+				"picomatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.40.1",
 			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.1.tgz",
@@ -1107,6 +1214,22 @@
 			},
 			"peerDependencies": {
 				"@sveltejs/kit": "^2.0.0"
+			}
+		},
+		"node_modules/@sveltejs/adapter-node": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.3.2.tgz",
+			"integrity": "sha512-nBJSipMb1KLjnAM7uzb+YpnA1VWKb+WdR+0mXEnXI6K1A3XYWbjkcjnW20ubg07sicK8XaGY/FAX3PItw39qBQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@rollup/plugin-commonjs": "^28.0.1",
+				"@rollup/plugin-json": "^6.1.0",
+				"@rollup/plugin-node-resolve": "^16.0.0",
+				"rollup": "^4.9.5"
+			},
+			"peerDependencies": {
+				"@sveltejs/kit": "^2.4.0"
 			}
 		},
 		"node_modules/@sveltejs/kit": {
@@ -1496,6 +1619,13 @@
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/resolve": {
+			"version": "1.20.2",
+			"resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1940,6 +2070,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/commondir": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2333,6 +2470,13 @@
 				"node": ">=4.0"
 			}
 		},
+		"node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2505,6 +2649,16 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/gaxios": {
 			"version": "6.7.1",
 			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
@@ -2629,6 +2783,19 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/https-proxy-agent": {
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -2691,6 +2858,22 @@
 				"node": ">=0.8.19"
 			}
 		},
+		"node_modules/is-core-module": {
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+			"integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2713,6 +2896,13 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/is-module": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+			"integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
@@ -3402,6 +3592,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/path-parse": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3720,6 +3917,27 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/resolve": {
+			"version": "1.22.10",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-core-module": "^2.16.0",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3931,6 +4149,19 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/svelte": {

--- a/frontend/src/routes/(app)/insights/+page.svelte
+++ b/frontend/src/routes/(app)/insights/+page.svelte
@@ -1,160 +1,584 @@
 <script lang="ts">
-  type Row = {
-    company: { id: number; name: string };
-    year: number;
-    ghg_total_value?: number;
-    energy_consumption_value?: number;
-    waste_generated_value?: number;
+  type InsightsData = {
+    status_tiles: {
+      companies_count: number;
+      validated_reports_count: number;
+      latest_submission: string | null;
+      portfolio_completeness: number;
+    };
+    kpi_trends: {
+      ghg_by_year: Array<{ year: number; value: number }>;
+      energy_by_year: Array<{ year: number; value: number }>;
+      waste_by_year: Array<{ year: number; value: number }>;
+      ghg_per_employee: Array<{ year: number; value: number }>;
+    };
+    quality_snapshot: {
+      units_analysis: Record<string, {
+        target_unit: string;
+        most_common_unit: string;
+        consistency_pct: number;
+        status: string;
+      }>;
+      portfolio_completeness: number;
+      distribution_data: {
+        year: number;
+        values: number[];
+        count: number;
+      } | null;
+    };
   };
 
-  let rows: Row[] = $state([]);
+  let data: InsightsData | null = $state(null);
   let loading: boolean = $state(false);
 
-  async function loadAll() {
+  async function loadInsights() {
     loading = true;
     try {
-      const res = await fetch('/api/vsme-register/', { credentials: 'include' });
-      if (res.ok) rows = await res.json();
+      const res = await fetch('/api/insights/aggregated/', { credentials: 'include' });
+      if (res.ok) {
+        const responseData = await res.json();
+        console.log('Insights data loaded:', responseData);
+        data = responseData;
+      } else {
+        console.error('Failed to load insights:', res.status, res.statusText);
+      }
+    } catch (error) {
+      console.error('Error loading insights:', error);
     } finally {
       loading = false;
     }
   }
 
-  function sum(arr: (number | undefined)[]): number {
-    return arr.reduce((s, v) => s + (Number(v) || 0), 0);
+  function formatNumber(n: number): string {
+    return n.toLocaleString();
   }
 
-  function fmt(n: number): string {
-    const x = Number(n || 0);
-    return x.toLocaleString();
+  function formatDate(isoString: string | null): string {
+    if (!isoString) return 'No data';
+    return new Date(isoString).toLocaleDateString();
   }
 
-  function byYearSum(accessor: (r: Row) => number | undefined): Array<{ yr: number; val: number }> {
-    const m = new Map<number, number>();
-    for (const r of rows) {
-      const v = Number(accessor(r) || 0);
-      if (!m.has(r.year)) m.set(r.year, 0);
-      m.set(r.year, m.get(r.year)! + v);
+  function createLineChart(data: Array<{ year: number; value: number }>, color: string = '#2563eb') {
+    if (data.length === 0) return { 
+      pathData: '', 
+      points: [] as Array<{ x: number; y: number; year: number; value: number }>, 
+      color, 
+      width: 460, 
+      height: 160, 
+      padding: 40 
+    };
+    
+    try {
+      const width = 460;
+      const height = 160;
+      const padding = 40;
+      
+      // Filter out invalid data
+      const validData = data.filter(d => 
+        typeof d.year === 'number' && 
+        typeof d.value === 'number' && 
+        !isNaN(d.year) && 
+        !isNaN(d.value) && 
+        isFinite(d.year) && 
+        isFinite(d.value)
+      );
+      
+      if (validData.length === 0) {
+        return { 
+          pathData: '', 
+          points: [], 
+          color, 
+          width, 
+          height, 
+          padding 
+        };
+      }
+      
+      const years = validData.map(d => d.year);
+      const values = validData.map(d => d.value);
+      const minYear = Math.min(...years);
+      const maxYear = Math.max(...years);
+      const minValue = Math.min(...values);
+      const maxValue = Math.max(...values);
+      
+      // Handle edge cases for scaling
+      const yearRange = maxYear - minYear;
+      const valueRange = maxValue - minValue;
+      
+      const xScale = (year: number) => {
+        if (yearRange === 0) return width / 2; // Center if single year
+        return padding + ((year - minYear) / yearRange) * (width - 2 * padding);
+      };
+      
+      const yScale = (value: number) => {
+        if (valueRange === 0) return height / 2; // Center if all values same
+        return height - padding - ((value - minValue) / valueRange) * (height - 2 * padding);
+      };
+      
+      let pathData = '';
+      const points = validData.map((d, i) => {
+        const x = xScale(d.year);
+        const y = yScale(d.value);
+        
+        // Ensure coordinates are valid
+        if (!isFinite(x) || !isFinite(y)) {
+          console.warn('Invalid chart coordinates:', { x, y, year: d.year, value: d.value });
+          return { x: padding, y: height - padding, year: d.year, value: d.value };
+        }
+        
+        if (i === 0) {
+          pathData += `M ${x} ${y}`;
+        } else {
+          pathData += ` L ${x} ${y}`;
+        }
+        return { x, y, year: d.year, value: d.value };
+      });
+      
+      return { pathData, points, color, width, height, padding };
+    } catch (error) {
+      console.error('Error creating line chart:', error, data);
+      return { 
+        pathData: '', 
+        points: [], 
+        color, 
+        width: 460, 
+        height: 160, 
+        padding: 40 
+      };
     }
-    return Array.from(m.entries()).map(([yr, val]) => ({ yr, val })).sort((a, b) => a.yr - b.yr);
   }
 
-  // KPIs (portfolio-wide totals)
-  let totalGHG = $derived(sum(rows.map((r) => r.ghg_total_value)));
-  let totalEnergy = $derived(sum(rows.map((r) => r.energy_consumption_value)));
-  let totalWaste = $derived(sum(rows.map((r) => r.waste_generated_value)));
-
-  // Charts: sums by year for the three metrics
-  let ghgSeries = $derived(byYearSum((r) => r.ghg_total_value));
-  let energySeries = $derived(byYearSum((r) => r.energy_consumption_value));
-  let wasteSeries = $derived(byYearSum((r) => r.waste_generated_value));
-
-  function toPoints(series: Array<{ yr: number; val: number }>) {
-    const n = series.length;
-    const maxVal = series.length ? Math.max(...series.map((p) => p.val)) : 0;
-    const scale = maxVal > 0 ? 180 / maxVal : 0;
-    return series.map((p, i) => ({
-      x: 40 + (n > 1 ? i * (420 / (n - 1)) : 0),
-      y: 200 - p.val * scale,
-      yr: p.yr,
-      val: p.val
-    }));
+  function createHistogram(values: number[]) {
+    const width = 320;
+    const height = 160;
+    const padding = 30;
+    
+    if (values.length === 0) return { 
+      bars: [] as Array<{ x: number; y: number; width: number; height: number; count: number; min: number; max: number }>, 
+      width, 
+      height, 
+      binCount: 0, 
+      valueCount: 0 
+    };
+    
+    try {
+      // Filter out invalid values
+      const validValues = values.filter(v => 
+        typeof v === 'number' && 
+        !isNaN(v) && 
+        isFinite(v)
+      );
+      
+      if (validValues.length === 0) {
+        return { 
+          bars: [], 
+          width, 
+          height, 
+          binCount: 0, 
+          valueCount: 0 
+        };
+      }
+      
+      // Create bins
+      const min = Math.min(...validValues);
+      const max = Math.max(...validValues);
+      const range = max - min;
+      
+      // Handle case where all values are the same
+      if (range === 0) {
+        const singleBar = {
+          x: padding,
+          y: padding,
+          width: width - 2 * padding,
+          height: height - 2 * padding,
+          count: validValues.length,
+          min: min,
+          max: max
+        };
+        return { 
+          bars: [singleBar], 
+          width, 
+          height, 
+          binCount: 1, 
+          valueCount: validValues.length 
+        };
+      }
+      
+      const binCount = Math.min(8, Math.ceil(Math.sqrt(validValues.length)));
+      const binSize = range / binCount;
+      
+      const bins = Array(binCount).fill(0).map((_, i) => ({
+        min: min + i * binSize,
+        max: min + (i + 1) * binSize,
+        count: 0
+      }));
+      
+      // Count values in bins
+      validValues.forEach(val => {
+        const binIndex = Math.min(Math.floor((val - min) / binSize), binCount - 1);
+        bins[binIndex].count++;
+      });
+      
+      const maxCount = Math.max(...bins.map(b => b.count));
+      const barWidth = (width - 2 * padding) / binCount;
+      
+      const bars = bins.map((bin, i) => ({
+        x: padding + i * barWidth,
+        y: height - padding - (maxCount > 0 ? (bin.count / maxCount) * (height - 2 * padding) : 0),
+        width: barWidth * 0.8,
+        height: maxCount > 0 ? (bin.count / maxCount) * (height - 2 * padding) : 0,
+        count: bin.count,
+        min: bin.min,
+        max: bin.max
+      }));
+      
+      return { bars, width, height, binCount, valueCount: validValues.length };
+    } catch (error) {
+      console.error('Error creating histogram:', error, values);
+      return { 
+        bars: [], 
+        width, 
+        height, 
+        binCount: 0, 
+        valueCount: 0 
+      };
+    }
   }
 
-  let ghgPoints = $derived(toPoints(ghgSeries));
-  let energyPoints = $derived(toPoints(energySeries));
-  let wastePoints = $derived(toPoints(wasteSeries));
-
-  $effect(() => { loadAll(); });
+  $effect(() => { loadInsights(); });
 </script>
 
 <div class="p-6 bg-base-200/40 min-h-screen">
-  <div class="mx-auto max-w-6xl space-y-6">
+  <div class="mx-auto max-w-7xl space-y-6">
+    <!-- Header -->
     <div class="flex items-end justify-between">
-      <h1 class="text-2xl font-semibold">Insights</h1>
-      <div class="text-sm opacity-70">Aggregated across your entire portfolio</div>
+      <div>
+        <h1 class="text-3xl font-bold">Indsigter</h1>
+        <p class="text-base-content/70 mt-1">Overblik over din porteføljes ESG-præstation på tværs af alle rapporter</p>
+      </div>
+      <div class="text-sm opacity-70">Aggregeret på tværs af hele din portefølje</div>
     </div>
+
     {#if loading}
-      <div>Loading…</div>
-    {:else}
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
-        <div class="rounded-box border border-base-300 p-4 bg-base-100 shadow-sm">
-          <div class="text-sm opacity-70">Total GHG emissions</div>
-          <div class="text-3xl font-semibold">{fmt(totalGHG)}</div>
+      <div class="flex items-center justify-center py-12">
+        <div class="loading loading-spinner loading-lg"></div>
+        <span class="ml-3">Indlæser indsigter...</span>
+      </div>
+    {:else if data}
+      <!-- Row 1: Status Tiles -->
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div class="bg-base-100 rounded-lg p-6 shadow-sm border border-base-300">
+          <div class="text-2xl font-bold text-primary">{formatNumber(data.status_tiles.companies_count)}</div>
+          <div class="text-sm text-base-content/70 mt-1">Virksomheder</div>
+          <div class="text-xs text-base-content/50 mt-2">Antal unikke virksomheder i portefølje</div>
         </div>
-        <div class="rounded-box border border-base-300 p-4 bg-base-100 shadow-sm">
-          <div class="text-sm opacity-70">Total energy consumption</div>
-          <div class="text-3xl font-semibold">{fmt(totalEnergy)}</div>
+        
+        <div class="bg-base-100 rounded-lg p-6 shadow-sm border border-base-300">
+          <div class="text-2xl font-bold text-success">{formatNumber(data.status_tiles.validated_reports_count)}</div>
+          <div class="text-sm text-base-content/70 mt-1">Validerede rapporter</div>
+          <div class="text-xs text-base-content/50 mt-2">Samlet antal validerede rapporter</div>
         </div>
-        <div class="rounded-box border border-base-300 p-4 bg-base-100 shadow-sm">
-          <div class="text-sm opacity-70">Total waste generated</div>
-          <div class="text-3xl font-semibold">{fmt(totalWaste)}</div>
+        
+        <div class="bg-base-100 rounded-lg p-6 shadow-sm border border-base-300">
+          <div class="text-2xl font-bold text-info">{formatDate(data.status_tiles.latest_submission)}</div>
+          <div class="text-sm text-base-content/70 mt-1">Seneste indsendelse</div>
+          <div class="text-xs text-base-content/50 mt-2">Nyeste validerede rapport</div>
+        </div>
+        
+        <div class="bg-base-100 rounded-lg p-6 shadow-sm border border-base-300">
+          <div class="text-2xl font-bold text-warning">{data.status_tiles.portfolio_completeness.toFixed(1)}%</div>
+          <div class="text-sm text-base-content/70 mt-1">Portefølje fuldstændighed</div>
+          <div class="text-xs text-base-content/50 mt-2">Gennemsnitlig fuldstændighedsscore</div>
         </div>
       </div>
 
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div class="rounded-box border border-base-300 p-4 bg-base-100 shadow-sm">
-          <div class="flex items-center justify-between mb-2">
-            <div class="font-semibold">GHG by year</div>
-            <div class="badge">Sum</div>
-          </div>
-        <svg viewBox="0 0 500 220" class="w-full h-52">
-          {#if ghgPoints.length === 0}
-            <text x="10" y="20">No data</text>
-          {:else}
-            {#each ghgPoints as p, i}
-              {#if i > 0}
-                <line x1={ghgPoints[i - 1].x} y1={ghgPoints[i - 1].y} x2={p.x} y2={p.y} stroke="#2563eb" stroke-width="2" />
+      <!-- Row 2: KPI Trend Charts -->
+      <div class="bg-base-100 rounded-lg p-6 shadow-sm border border-base-300">
+        <h2 class="text-xl font-semibold mb-4">KPI-tendenser efter år</h2>
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <!-- GHG Chart -->
+          <div class="space-y-2">
+            <h3 class="font-medium">Samlet drivhusgasudledning (tCO₂e)</h3>
+            {#if data.kpi_trends.ghg_by_year.length >= 2}
+              {@const chart = createLineChart(data.kpi_trends.ghg_by_year, '#dc2626')}
+              {#if chart && chart.pathData}
+                <div class="h-48 bg-base-200 rounded p-2">
+                  <svg viewBox="0 0 {chart.width} {chart.height}" class="w-full h-full">
+                    <!-- Grid lines -->
+                    <defs>
+                      <pattern id="grid" width="40" height="20" patternUnits="userSpaceOnUse">
+                        <path d="M 40 0 L 0 0 0 20" fill="none" stroke="#e5e7eb" stroke-width="0.5"/>
+                      </pattern>
+                    </defs>
+                    <rect width="100%" height="100%" fill="url(#grid)" opacity="0.3"/>
+                    
+                    <!-- Line -->
+                    <path d={chart.pathData} fill="none" stroke={chart.color} stroke-width="2"/>
+                    
+                    <!-- Points -->
+                    {#each chart.points as point}
+                      <circle cx={point.x} cy={point.y} r="3" fill={chart.color}/>
+                      <text x={point.x} y={chart.height - 10} font-size="10" text-anchor="middle" fill="currentColor">{point.year}</text>
+                    {/each}
+                  </svg>
+                </div>
+              {:else}
+                <div class="h-48 bg-base-200 rounded p-4 flex items-center justify-center">
+                  <div class="text-sm text-base-content/50">Fejl ved diagram</div>
+                </div>
               {/if}
-              <circle cx={p.x} cy={p.y} r="3" fill="#2563eb" />
-              <text x={p.x} y="210" font-size="10">{p.yr}</text>
-            {/each}
-          {/if}
-        </svg>
-          <div class="mt-1 text-xs opacity-70">Totals per year</div>
+              <div class="text-xs text-base-content/50">
+                Seneste: {formatNumber(data.kpi_trends.ghg_by_year[data.kpi_trends.ghg_by_year.length - 1]?.value || 0)} tCO₂e
+              </div>
+            {:else}
+              <div class="h-48 bg-base-200 rounded p-4 flex items-center justify-center">
+                <div class="text-sm text-base-content/50">Utilstrækkelige data - kræver ≥2 årlige datapunkter</div>
+              </div>
+            {/if}
+          </div>
+
+          <!-- Energy Chart -->
+          <div class="space-y-2">
+            <h3 class="font-medium">Energiforbrug (MWh)</h3>
+            {#if data.kpi_trends.energy_by_year.length >= 2}
+              {@const chart = createLineChart(data.kpi_trends.energy_by_year, '#16a34a')}
+              {#if chart && chart.pathData}
+                <div class="h-48 bg-base-200 rounded p-2">
+                  <svg viewBox="0 0 {chart.width} {chart.height}" class="w-full h-full">
+                    <!-- Grid lines -->
+                    <defs>
+                      <pattern id="grid-energy" width="40" height="20" patternUnits="userSpaceOnUse">
+                        <path d="M 40 0 L 0 0 0 20" fill="none" stroke="#e5e7eb" stroke-width="0.5"/>
+                      </pattern>
+                    </defs>
+                    <rect width="100%" height="100%" fill="url(#grid-energy)" opacity="0.3"/>
+                    
+                    <!-- Line -->
+                    <path d={chart.pathData} fill="none" stroke={chart.color} stroke-width="2"/>
+                    
+                    <!-- Points -->
+                    {#each chart.points as point}
+                      <circle cx={point.x} cy={point.y} r="3" fill={chart.color}/>
+                      <text x={point.x} y={chart.height - 10} font-size="10" text-anchor="middle" fill="currentColor">{point.year}</text>
+                    {/each}
+                  </svg>
+                </div>
+              {:else}
+                <div class="h-48 bg-base-200 rounded p-4 flex items-center justify-center">
+                  <div class="text-sm text-base-content/50">Fejl ved diagram</div>
+                </div>
+              {/if}
+              <div class="text-xs text-base-content/50">
+                Seneste: {formatNumber(data.kpi_trends.energy_by_year[data.kpi_trends.energy_by_year.length - 1]?.value || 0)} MWh
+              </div>
+            {:else}
+              <div class="h-48 bg-base-200 rounded p-4 flex items-center justify-center">
+                <div class="text-sm text-base-content/50">Utilstrækkelige data - kræver ≥2 årlige datapunkter</div>
+              </div>
+            {/if}
+          </div>
+
+          <!-- Waste Chart -->
+          <div class="space-y-2">
+            <h3 class="font-medium">Affald genereret (t)</h3>
+            {#if data.kpi_trends.waste_by_year.length >= 2}
+              {@const chart = createLineChart(data.kpi_trends.waste_by_year, '#f59e0b')}
+              {#if chart && chart.pathData}
+                <div class="h-48 bg-base-200 rounded p-2">
+                  <svg viewBox="0 0 {chart.width} {chart.height}" class="w-full h-full">
+                    <!-- Grid lines -->
+                    <defs>
+                      <pattern id="grid-waste" width="40" height="20" patternUnits="userSpaceOnUse">
+                        <path d="M 40 0 L 0 0 0 20" fill="none" stroke="#e5e7eb" stroke-width="0.5"/>
+                      </pattern>
+                    </defs>
+                    <rect width="100%" height="100%" fill="url(#grid-waste)" opacity="0.3"/>
+                    
+                    <!-- Line -->
+                    <path d={chart.pathData} fill="none" stroke={chart.color} stroke-width="2"/>
+                    
+                    <!-- Points -->
+                    {#each chart.points as point}
+                      <circle cx={point.x} cy={point.y} r="3" fill={chart.color}/>
+                      <text x={point.x} y={chart.height - 10} font-size="10" text-anchor="middle" fill="currentColor">{point.year}</text>
+                    {/each}
+                  </svg>
+                </div>
+              {:else}
+                <div class="h-48 bg-base-200 rounded p-4 flex items-center justify-center">
+                  <div class="text-sm text-base-content/50">Fejl ved diagram</div>
+                </div>
+              {/if}
+              <div class="text-xs text-base-content/50">
+                Seneste: {formatNumber(data.kpi_trends.waste_by_year[data.kpi_trends.waste_by_year.length - 1]?.value || 0)} t
+              </div>
+            {:else}
+              <div class="h-48 bg-base-200 rounded p-4 flex items-center justify-center">
+                <div class="text-sm text-base-content/50">Utilstrækkelige data - kræver ≥2 årlige datapunkter</div>
+              </div>
+            {/if}
+          </div>
         </div>
 
-        <div class="rounded-box border border-base-300 p-4 bg-base-100 shadow-sm">
-          <div class="flex items-center justify-between mb-2">
-            <div class="font-semibold">Energy by year</div>
-            <div class="badge">Sum</div>
+        <!-- Optional Intensity Chart -->
+        {#if data.kpi_trends.ghg_per_employee.length >= 2}
+          {@const chart = createLineChart(data.kpi_trends.ghg_per_employee, '#8b5cf6')}
+          <div class="mt-6 pt-6 border-t border-base-300">
+            <h3 class="font-medium mb-2">Drivhusgasudledning pr. medarbejder (tCO₂e/medarbejder)</h3>
+            {#if chart && chart.pathData}
+              <div class="h-32 bg-base-200 rounded p-2">
+                <svg viewBox="0 0 {chart.width} {chart.height}" class="w-full h-full">
+                  <!-- Grid lines -->
+                  <defs>
+                    <pattern id="grid-intensity" width="40" height="20" patternUnits="userSpaceOnUse">
+                      <path d="M 40 0 L 0 0 0 20" fill="none" stroke="#e5e7eb" stroke-width="0.5"/>
+                    </pattern>
+                  </defs>
+                  <rect width="100%" height="100%" fill="url(#grid-intensity)" opacity="0.3"/>
+                  
+                  <!-- Line -->
+                  <path d={chart.pathData} fill="none" stroke={chart.color} stroke-width="2"/>
+                  
+                  <!-- Points -->
+                  {#each chart.points as point}
+                    <circle cx={point.x} cy={point.y} r="2" fill={chart.color}/>
+                    <text x={point.x} y={chart.height - 5} font-size="9" text-anchor="middle" fill="currentColor">{point.year}</text>
+                  {/each}
+                </svg>
+              </div>
+            {:else}
+              <div class="h-32 bg-base-200 rounded p-4 flex items-center justify-center">
+                <div class="text-sm text-base-content/50">Fejl ved diagram</div>
+              </div>
+            {/if}
+            <div class="text-xs text-base-content/50 mt-1">
+              Beregnet kun for år med medarbejderdata
+            </div>
           </div>
-        <svg viewBox="0 0 500 220" class="w-full h-52">
-          {#if energyPoints.length === 0}
-            <text x="10" y="20">No data</text>
-          {:else}
-            {#each energyPoints as p, i}
-              {#if i > 0}
-                <line x1={energyPoints[i - 1].x} y1={energyPoints[i - 1].y} x2={p.x} y2={p.y} stroke="#16a34a" stroke-width="2" />
-              {/if}
-              <circle cx={p.x} cy={p.y} r="3" fill="#16a34a" />
-              <text x={p.x} y="210" font-size="10">{p.yr}</text>
-            {/each}
-          {/if}
-        </svg>
-          <div class="mt-1 text-xs opacity-70">Totals per year</div>
+        {/if}
+      </div>
+
+      <!-- Row 3: Quality Snapshot & Distribution -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <!-- Quality Snapshot -->
+        <div class="bg-base-100 rounded-lg p-6 shadow-sm border border-base-300">
+          <h2 class="text-xl font-semibold mb-4">Kvalitetsoverblik</h2>
+          <div class="space-y-3">
+            <!-- Units & Completeness Table -->
+            <div class="overflow-x-auto">
+              <table class="table table-sm">
+                <thead>
+                  <tr>
+                    <th>KPI</th>
+                    <th>Målenhed</th>
+                    <th>Mest almindelig</th>
+                    <th>Konsistens</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each Object.entries(data.quality_snapshot.units_analysis) as [kpi, analysis]}
+                    <tr>
+                      <td class="font-mono text-xs">{kpi}</td>
+                      <td class="text-xs">{analysis.target_unit}</td>
+                      <td class="text-xs">{analysis.most_common_unit}</td>
+                      <td class="text-xs">{analysis.consistency_pct}%</td>
+                      <td>
+                        {#if analysis.status === 'OK'}
+                          <span class="badge badge-success badge-xs">OK</span>
+                        {:else if analysis.status === 'Mixed'}
+                          <span class="badge badge-warning badge-xs">⚠️ Blandet</span>
+                        {:else}
+                          <span class="badge badge-ghost badge-xs">Ingen data</span>
+                        {/if}
+                      </td>
+                    </tr>
+                  {/each}
+                  <tr class="border-t-2">
+                    <td class="font-medium">Portefølje</td>
+                    <td colspan="3" class="text-xs text-base-content/70">Samlet fuldstændighed</td>
+                    <td class="font-bold">{data.quality_snapshot.portfolio_completeness.toFixed(1)}%</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
         </div>
 
-        <div class="rounded-box border border-base-300 p-4 bg-base-100 shadow-sm">
-          <div class="flex items-center justify-between mb-2">
-            <div class="font-semibold">Waste by year</div>
-            <div class="badge">Sum</div>
-          </div>
-        <svg viewBox="0 0 500 220" class="w-full h-52">
-          {#if wastePoints.length === 0}
-            <text x="10" y="20">No data</text>
-          {:else}
-            {#each wastePoints as p, i}
-              {#if i > 0}
-                <line x1={wastePoints[i - 1].x} y1={wastePoints[i - 1].y} x2={p.x} y2={p.y} stroke="#f59e0b" stroke-width="2" />
+        <!-- Distribution Chart -->
+        <div class="bg-base-100 rounded-lg p-6 shadow-sm border border-base-300">
+          <h2 class="text-xl font-semibold mb-4">Fordeling</h2>
+          {#if data.quality_snapshot.distribution_data}
+            {@const histogram = createHistogram(data.quality_snapshot.distribution_data.values)}
+            <div class="space-y-2">
+              <h3 class="font-medium">Fordeling af samlet drivhusgasudledning ({data.quality_snapshot.distribution_data.year})</h3>
+              {#if histogram && histogram.bars.length > 0}
+                <div class="h-48 bg-base-200 rounded p-2">
+                  <svg viewBox="0 0 {histogram.width} {histogram.height}" class="w-full h-full">
+                    <!-- Histogram bars -->
+                    {#each histogram.bars as bar}
+                      <rect 
+                        x={bar.x} 
+                        y={bar.y} 
+                        width={bar.width} 
+                        height={bar.height} 
+                        fill="#3b82f6" 
+                        stroke="#1d4ed8" 
+                        stroke-width="1"
+                        opacity="0.8"
+                      />
+                      <!-- Count labels on bars -->
+                      {#if bar.count > 0}
+                        <text 
+                          x={bar.x + bar.width / 2} 
+                          y={bar.y - 5} 
+                          font-size="10" 
+                          text-anchor="middle" 
+                          fill="currentColor"
+                        >
+                          {bar.count}
+                        </text>
+                      {/if}
+                    {/each}
+                  </svg>
+                </div>
+              {:else}
+                <div class="h-48 bg-base-200 rounded p-4 flex items-center justify-center">
+                  <div class="text-sm text-base-content/50">Fejl ved histogram</div>
+                </div>
               {/if}
-              <circle cx={p.x} cy={p.y} r="3" fill="#f59e0b" />
-              <text x={p.x} y="210" font-size="10">{p.yr}</text>
-            {/each}
+              <div class="text-xs text-base-content/50">
+                {data.quality_snapshot.distribution_data.count} virksomheder, {histogram.binCount} intervaller
+                · Seneste år med ≥5 virksomheder der rapporterer drivhusgasdata
+              </div>
+            </div>
+          {:else}
+            <div class="h-48 bg-base-200 rounded p-4 flex items-center justify-center">
+              <div class="text-center">
+                <div class="text-sm text-base-content/50">Utilstrækkelige data</div>
+                <div class="text-xs text-base-content/40 mt-1">Kræver ≥5 virksomheder med drivhusgasdata</div>
+              </div>
+            </div>
           {/if}
-        </svg>
-          <div class="mt-1 text-xs opacity-70">Totals per year</div>
         </div>
+      </div>
+    {:else if data && data.status_tiles && data.status_tiles.companies_count === 0}
+      <!-- Empty Portfolio State -->
+      <div class="text-center py-16">
+        <div class="max-w-md mx-auto">
+          <div class="text-6xl mb-4">📊</div>
+          <h2 class="text-2xl font-semibold mb-2">Din portefølje er tom</h2>
+          <p class="text-base-content/70 mb-6">
+            Upload nogle validerede rapporter for at se indsigter om din porteføljes ESG-præstation.
+          </p>
+          <a href="/submit" class="btn btn-primary">
+            Upload din første rapport
+          </a>
+        </div>
+      </div>
+    {:else}
+      <div class="text-center py-12 text-base-content/50">
+        Ingen indsigtsdata tilgængelige
       </div>
     {/if}
   </div>

--- a/frontend/src/routes/(app)/portfolio/+page.svelte
+++ b/frontend/src/routes/(app)/portfolio/+page.svelte
@@ -13,7 +13,7 @@
   }
 
   async function onDelete(id: number) {
-    if (!confirm('Delete this report?')) return;
+    if (!confirm('Slet denne rapport?')) return;
     deleting[id] = true;
     try {
       const res = await fetch(`/api/reports/${id}/delete/`, { method: 'DELETE', credentials: 'include' });
@@ -47,12 +47,12 @@
 <!-- Visual refresh only: keep existing behavior, remove hardcoded labels -->
 <div class="bg-base-200/60 border-b">
   <div class="mx-auto max-w-6xl px-4 py-8">
-    <h1 class="text-xl font-semibold">Portfolio</h1>
+    <h1 class="text-xl font-semibold">Portefølje</h1>
 
     <div class="mt-4 rounded-box border border-base-300 bg-base-100 p-6 shadow-md">
       <form class="mx-auto max-w-3xl flex items-stretch gap-2" onsubmit={(e) => { e.preventDefault(); loadReports(); }}>
-        <input class="input input-bordered input-lg w-full" placeholder="Search portfolio (company or year)" bind:value={q} />
-        <button class="btn btn-neutral btn-lg" type="submit">Search</button>
+        <input class="input input-bordered input-lg w-full" placeholder="Søg i portefølje (virksomhed eller år)" bind:value={q} />
+        <button class="btn btn-neutral btn-lg" type="submit">Søg</button>
       </form>
     </div>
   </div>
@@ -61,11 +61,11 @@
 <div class="px-4 pt-8 pb-6 bg-base-200/40 min-h-screen">
   <div class="mx-auto max-w-6xl">
     <div class="flex items-center justify-between">
-      <div class="text-lg font-medium">Found {reports.length} result{reports.length === 1 ? '' : 's'}</div>
+      <div class="text-lg font-medium">Fandt {reports.length} resultat{reports.length === 1 ? '' : 'er'}</div>
     </div>
 
     {#if reports.length === 0}
-      <div class="mt-4 text-sm opacity-75">No reports match your search.</div>
+      <div class="mt-4 text-sm opacity-75">Ingen rapporter matcher din søgning.</div>
     {:else}
       <div class="mt-4 space-y-3">
         {#each reports as r}
@@ -73,16 +73,18 @@
             <div class="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-3">
               <div class="min-w-0 space-y-1">
                 <div class="text-base font-semibold truncate">{r.company?.name || '—'}</div>
-                <div class="text-xs opacity-70 truncate">Entity: {r.entity || '—'}</div>
-                <div class="text-xs opacity-70">Reporting period: {formatPeriod(r.reporting_period)}</div>
-                <div class="text-xs opacity-70">Created: {formatDate(r.created_at)}</div>
+                <div class="text-xs opacity-70 truncate">Enhed: {r.entity || '—'}</div>
+                <div class="text-xs opacity-70">Rapporteringsperiode: {formatPeriod(r.reporting_period)}</div>
+                <div class="text-xs opacity-70">Oprettet: {formatDate(r.created_at)}</div>
               </div>
               <div class="flex items-start md:items-center gap-2 md:justify-end">
-                <span class="badge badge-outline">Year {r.reporting_year || '—'}</span>
-                <span class={`badge ${r.status === 'validated' ? 'badge-success' : r.status === 'failed' ? 'badge-error' : ''}`}>{r.status}</span>
-                <button class="btn btn-ghost btn-sm" onclick={() => goto(`/reports/${r.id}`)}>Open</button>
-                <a class="btn btn-ghost btn-sm" href={`/api/reports/${r.id}/document/`} target="_blank">Inspect</a>
-                <button class="btn btn-error btn-sm" disabled={!!deleting[r.id]} onclick={() => onDelete(r.id)}>Delete</button>
+                <span class="badge badge-outline">År {r.reporting_year || '—'}</span>
+                <span class={`badge ${r.status === 'validated' ? 'badge-success' : r.status === 'failed' ? 'badge-error' : ''}`}>
+                  {r.status === 'validated' ? 'valideret' : r.status === 'failed' ? 'fejlet' : r.status === 'processing' ? 'behandler' : r.status}
+                </span>
+                <button class="btn btn-ghost btn-sm" onclick={() => goto(`/reports/${r.id}`)}>Åbn</button>
+                <a class="btn btn-ghost btn-sm" href={`/api/reports/${r.id}/document/`} target="_blank">Inspicer</a>
+                <button class="btn btn-error btn-sm" disabled={!!deleting[r.id]} onclick={() => onDelete(r.id)}>Slet</button>
               </div>
             </div>
           </div>

--- a/frontend/src/routes/(app)/reports/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/reports/[id]/+page.svelte
@@ -112,30 +112,32 @@
   <div class="mx-auto max-w-5xl space-y-6">
     <div class="flex items-start justify-between">
       <div>
-        <button class="btn btn-ghost" onclick={() => goto('/portfolio')}>← Back</button>
-        <h1 class="text-2xl font-semibold mt-2">Report #{report?.id ?? ''}</h1>
+        <button class="btn btn-ghost" onclick={() => goto('/portfolio')}>← Tilbage</button>
+        <h1 class="text-2xl font-semibold mt-2">Rapport #{report?.user_report_number ?? report?.id ?? ''}</h1>
         <div class="text-sm opacity-80 mt-1">
-          <span>Company: {report?.company?.name || '—'}</span>
+          <span>Virksomhed: {report?.company?.name || '—'}</span>
           <span class="mx-2">•</span>
-          <span>Year: {report?.reporting_year || '—'}</span>
+          <span>År: {report?.reporting_year || '—'}</span>
         </div>
       </div>
       <div class="flex gap-2">
-        <button class="btn btn-error btn-sm" disabled={deleteBusy} onclick={onDelete}>Delete</button>
+        <button class="btn btn-error btn-sm" disabled={deleteBusy} onclick={onDelete}>Slet</button>
       </div>
     </div>
 
   {#if !report}
-    <div>Loading…</div>
+    <div>Indlæser…</div>
   {:else}
     <div class="grid gap-4 md:grid-cols-2">
       <div class="rounded-box border border-base-300 bg-base-100 p-4 shadow-sm">
         <div class="text-sm opacity-80 space-y-1">
-          <div>Entity: {report.entity || '—'}</div>
-          <div>Reporting Period: {report.reporting_period || '—'}</div>
-          <div>Taxonomy Version: {report.taxonomy_version || '—'}</div>
-          <div>Status: <span class="badge {report.status === 'validated' ? 'badge-success' : report.status === 'failed' ? 'badge-error' : 'badge-ghost'}">{report.status}</span></div>
-          <div>Created: {new Date(report.created_at).toLocaleString()}</div>
+          <div>Enhed: {report.entity || '—'}</div>
+          <div>Rapporteringsperiode: {report.reporting_period || '—'}</div>
+          <div>Taksonomi version: {report.taxonomy_version || '—'}</div>
+          <div>Status: <span class="badge {report.status === 'validated' ? 'badge-success' : report.status === 'failed' ? 'badge-error' : 'badge-ghost'}">
+            {report.status === 'validated' ? 'valideret' : report.status === 'failed' ? 'fejlet' : report.status === 'processing' ? 'behandler' : report.status}
+          </span></div>
+          <div>Oprettet: {new Date(report.created_at).toLocaleString()}</div>
         </div>
 
         <div class="mt-4 flex flex-wrap gap-2">
@@ -143,17 +145,17 @@
             <a class="btn btn-sm" href={`../../api/reports/${report.id}/download/original/`}>Download original iXBRL</a>
           {/if}
           {#if report.oim_json_file_url}
-            <a class="btn btn-sm" href={`../../api/reports/${report.id}/download/oim-json/`}>Download extracted JSON</a>
+            <a class="btn btn-sm" href={`../../api/reports/${report.id}/download/oim-json/`}>Download udtrukket JSON</a>
           {/if}
-          <button class="btn btn-sm" onclick={inspectInline}>Inspect report</button>
+          <button class="btn btn-sm" onclick={inspectInline}>Inspicer rapport</button>
         </div>
       </div>
 
       <div class="rounded-box border border-base-300 bg-base-100 p-4 shadow-sm">
         {#if report.status === 'validated'}
-          <h2 class="text-lg font-semibold mb-2">vSME ESG Summary</h2>
+          <h2 class="text-lg font-semibold mb-2">vSME ESG Sammendrag</h2>
           {#if summary}
-            <div class="text-sm opacity-80 mb-2">Entity: {summary.entity || '—'} • Period: {summary.reporting_period || '—'} • Facts: {summary.fact_count}</div>
+            <div class="text-sm opacity-80 mb-2">Enhed: {summary.entity || '—'} • Periode: {summary.reporting_period || '—'} • Fakta: {summary.fact_count}</div>
             <ul class="space-y-1">
               {#each summary.items as item}
                 <li class="flex items-center justify-between">

--- a/frontend/src/routes/(app)/submit/+page.svelte
+++ b/frontend/src/routes/(app)/submit/+page.svelte
@@ -10,7 +10,7 @@
     const formEl = ev.target as HTMLFormElement;
     const fileInput = formEl.querySelector('#ixbrl-file') as HTMLInputElement;
     if (!fileInput?.files || fileInput.files.length === 0) { 
-      uploadError = 'Please choose a file'; 
+      uploadError = 'Vælg venligst en fil'; 
       return; 
     }
     
@@ -32,7 +32,7 @@
         // Check if error suggests we need company info
         if (text.includes('company name') || text.includes('entity information')) {
           showFallback = true;
-          uploadError = 'Could not extract company information from file. Please provide company name below.';
+          uploadError = 'Kunne ikke udtrække virksomhedsoplysninger fra filen. Angiv venligst virksomhedsnavn nedenfor.';
         } else {
           uploadError = text || res.statusText;
         }
@@ -41,40 +41,40 @@
         goto(`/reports/${data.id}`);
       }
     } catch (e) {
-      uploadError = 'Upload failed';
+      uploadError = 'Upload fejlede';
     } finally {
       uploading = false;
     }
   }
 </script>
 
-<div class="min-h-screen bg-base-200/40 flex items-center justify-center px-4">
+<div class="min-h-screen bg-base-200/40 flex items-start justify-center pt-20 px-4">
   <div class="w-full max-w-2xl rounded-box border border-base-300 bg-base-100 p-6 shadow-md space-y-5">
-    <h1 class="text-2xl font-semibold text-center">Submit report</h1>
+    <h1 class="text-2xl font-semibold text-center">Indsend rapport</h1>
     <p class="text-center text-base-content/70">
-      Upload your iXBRL vSME report
+      Upload din iXBRL vSME rapport
     </p>
     <form class="space-y-4" onsubmit={onSubmit}>
       {#if uploadError}
         <div class="alert alert-error"><span>{uploadError}</span></div>
       {/if}
       <div class="form-control">
-        <div class="mb-1 text-sm font-medium">iXBRL file (.xhtml, .html, or .zip)</div>
+        <div class="mb-1 text-sm font-medium">iXBRL fil (.xhtml, .html eller .zip)</div>
         <input id="ixbrl-file" class="file-input file-input-bordered w-full" type="file" accept=".xhtml,.html,.zip" />
       </div>
       
       {#if showFallback}
         <div class="form-control">
-          <div class="mb-1 text-sm font-medium">Company name</div>
+          <div class="mb-1 text-sm font-medium">Virksomhedsnavn</div>
           <input 
             bind:value={fallbackCompanyName} 
             class="input input-bordered w-full" 
             type="text" 
-            placeholder="Enter company name" 
+            placeholder="Indtast virksomhedsnavn" 
             required={showFallback}
           />
           <div class="text-xs text-base-content/60 mt-1">
-            We couldn't extract the company name from your file automatically.
+            Vi kunne ikke udtrække virksomhedsnavnet fra din fil automatisk.
           </div>
         </div>
       {/if}
@@ -82,9 +82,9 @@
       <div class="pt-2">
         <button class="btn btn-primary w-full sm:w-auto" type="submit" disabled={uploading}>
           {#if uploading}
-            <span class="loading loading-spinner loading-sm"></span> Processing…
+            <span class="loading loading-spinner loading-sm"></span> Behandler…
           {:else}
-            Submit
+            Indsend
           {/if}
         </button>
       </div>

--- a/frontend/src/routes/(app)/submit/+page.svelte
+++ b/frontend/src/routes/(app)/submit/+page.svelte
@@ -1,62 +1,41 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
-  let companies: any[] = $state([]);
-  let selectedCompanyId: string = $state('');
-  let selectedYear: string = $state('');
   let uploading: boolean = $state(false);
   let uploadError: string | null = $state(null);
-  let newCompanyName: string = $state('');
-  let creatingCompany: boolean = $state(false);
-
-  async function loadCompanies() {
-    const res = await fetch('/api/companies/', { credentials: 'include' });
-    if (res.ok) {
-      companies = await res.json();
-    }
-  }
-
-  async function createCompany() {
-    const name = (newCompanyName || '').trim();
-    if (!name) return;
-    creatingCompany = true;
-    try {
-      const res = await fetch('/api/companies/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ name })
-      });
-      if (res.ok || res.status === 201) {
-        const c = await res.json();
-        await loadCompanies();
-        selectedCompanyId = String(c.id);
-        newCompanyName = '';
-      } else {
-        uploadError = await res.text();
-      }
-    } finally {
-      creatingCompany = false;
-    }
-  }
+  let showFallback: boolean = $state(false);
+  let fallbackCompanyName: string = $state('');
 
   async function onSubmit(ev: Event) {
     ev.preventDefault();
     const formEl = ev.target as HTMLFormElement;
     const fileInput = formEl.querySelector('#ixbrl-file') as HTMLInputElement;
-    if (!fileInput?.files || fileInput.files.length === 0) { uploadError = 'Please choose a file'; return; }
-    if (!selectedCompanyId) { uploadError = 'Please select or create a company'; return; }
-    if (!selectedYear) { uploadError = 'Please enter a year'; return; }
+    if (!fileInput?.files || fileInput.files.length === 0) { 
+      uploadError = 'Please choose a file'; 
+      return; 
+    }
+    
     const formData = new FormData();
     formData.append('original_file', fileInput.files[0]);
-    formData.append('company', selectedCompanyId);
-    formData.append('reporting_year', selectedYear);
+    
+    // Add company name if provided in fallback
+    if (showFallback && fallbackCompanyName.trim()) {
+      formData.append('company_name', fallbackCompanyName.trim());
+    }
+    
     uploadError = null;
     uploading = true;
+    
     try {
       const res = await fetch('/api/reports/upload', { method: 'POST', body: formData, credentials: 'include' });
       if (!res.ok) {
         const text = await res.text();
-        uploadError = text || res.statusText;
+        // Check if error suggests we need company info
+        if (text.includes('company name') || text.includes('entity information')) {
+          showFallback = true;
+          uploadError = 'Could not extract company information from file. Please provide company name below.';
+        } else {
+          uploadError = text || res.statusText;
+        }
       } else {
         const data = await res.json();
         goto(`/reports/${data.id}`);
@@ -67,51 +46,43 @@
       uploading = false;
     }
   }
-
-  $effect(() => { loadCompanies(); });
 </script>
 
-<div class="min-h-screen bg-base-200/40 py-10 px-4">
-  <div class="mx-auto w-full max-w-2xl rounded-box border border-base-300 bg-base-100 p-6 shadow-md space-y-5">
+<div class="min-h-screen bg-base-200/40 flex items-center justify-center px-4">
+  <div class="w-full max-w-2xl rounded-box border border-base-300 bg-base-100 p-6 shadow-md space-y-5">
     <h1 class="text-2xl font-semibold text-center">Submit report</h1>
+    <p class="text-center text-base-content/70">
+      Upload your iXBRL vSME report
+    </p>
     <form class="space-y-4" onsubmit={onSubmit}>
       {#if uploadError}
         <div class="alert alert-error"><span>{uploadError}</span></div>
       {/if}
       <div class="form-control">
-        <div class="mb-1 text-sm font-medium">Company</div>
-        <select id="company-select" class="select select-bordered w-full" bind:value={selectedCompanyId}>
-          <option value="">Select company…</option>
-          {#each companies as c}
-            <option value={String(c.id)}>{c.name}</option>
-          {/each}
-        </select>
-      </div>
-      <div class="form-control">
-        <div class="mb-1 text-sm font-medium">Or create company</div>
-        <div class="flex gap-2">
-          <input id="new-company" class="input input-bordered flex-1" placeholder="Acme Ltd" bind:value={newCompanyName} />
-          <button class="btn" type="button" disabled={creatingCompany || !newCompanyName.trim()} onclick={createCompany}>
-            {#if creatingCompany}
-              <span class="loading loading-spinner loading-sm"></span>
-            {:else}
-              Create
-            {/if}
-          </button>
-        </div>
-      </div>
-      <div class="form-control">
-        <div class="mb-1 text-sm font-medium">Tax year</div>
-        <input id="tax-year" class="input input-bordered w-36" type="number" min="1900" max="2100" placeholder="2024" bind:value={selectedYear} />
-      </div>
-      <div class="form-control">
         <div class="mb-1 text-sm font-medium">iXBRL file (.xhtml, .html, or .zip)</div>
         <input id="ixbrl-file" class="file-input file-input-bordered w-full" type="file" accept=".xhtml,.html,.zip" />
       </div>
+      
+      {#if showFallback}
+        <div class="form-control">
+          <div class="mb-1 text-sm font-medium">Company name</div>
+          <input 
+            bind:value={fallbackCompanyName} 
+            class="input input-bordered w-full" 
+            type="text" 
+            placeholder="Enter company name" 
+            required={showFallback}
+          />
+          <div class="text-xs text-base-content/60 mt-1">
+            We couldn't extract the company name from your file automatically.
+          </div>
+        </div>
+      {/if}
+      
       <div class="pt-2">
         <button class="btn btn-primary w-full sm:w-auto" type="submit" disabled={uploading}>
           {#if uploading}
-            <span class="loading loading-spinner loading-sm"></span> Uploading…
+            <span class="loading loading-spinner loading-sm"></span> Processing…
           {:else}
             Submit
           {/if}

--- a/frontend/src/routes/(auth)/login/+page.svelte
+++ b/frontend/src/routes/(auth)/login/+page.svelte
@@ -6,34 +6,34 @@
 <div class="hero bg-base-200 min-h-[95vh]">
 	<div class="flex-col">
 		<div class="mb-10 text-center lg:text-left">
-			<h1 class="text-5xl font-bold">Login now!</h1>
-			<p class="mt-2 text-sm opacity-70">Demo instance — for testing only</p>
+			<h1 class="text-5xl font-bold">Log ind</h1>
+			<p class="mt-2 text-sm opacity-70">IXBRL VSME Læser</p>
 		</div>
 		<div class="card bg-base-100 w-full max-w-sm min-w-sm shrink-0 shadow-2xl">
 			<div class="card-body">
                 <form action="?/login" method="post">
 					<fieldset class="fieldset">
-						<label for="email" class="label">Email</label>
+						<label for="email" class="label">E-mail</label>
 						<input
 							required
 							type="email"
 							name="username"
 							id="username"
 							class="input"
-							placeholder="Email address"
+							placeholder="E-mail adresse"
 						/>
-						<label for="password" class="label">Password</label>
+						<label for="password" class="label">Adgangskode</label>
 						<input
 							required
 							type="password"
 							class="input"
 							name="password"
 							id="password"
-							placeholder="Password"
+							placeholder="Adgangskode"
 						/>
-						<div><a class="link link-hover" href="/">Forgot password?</a></div>
-                        <button type="submit" class="btn btn-neutral mt-4"> Login </button>
-						<button type="button" class="btn" onclick={() => goto('/')}> Back </button>
+						<div><a class="link link-hover" href="/">Glemt adgangskode?</a></div>
+                        <button type="submit" class="btn btn-neutral mt-4"> Log ind </button>
+						<button type="button" class="btn" onclick={() => goto('/')}> Tilbage </button>
 					</fieldset>
 				</form>
                 {#if form?.message}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -13,18 +13,18 @@
 			<div class="flex items-stretch">
 				<!-- Left section: brand -->
 				<div class="px-4 py-6 flex items-center">
-					<a class="text-xl font-semibold select-none">IXBRL VSME Reader</a>
+					<a class="text-xl font-semibold select-none">IXBRL VSME Læser</a>
 				</div>
 				<!-- Divider -->
 				<div class="w-px bg-base-300/80 my-2"></div>
 				<!-- Middle section: nav links -->
 				<div class="flex items-center px-1">
 					{#if data.authed}
-						<a class="px-4 py-6 hover:bg-base-200/60" href="/submit">Submit report</a>
+						<a class="px-4 py-6 hover:bg-base-200/60" href="/submit">Indsend rapport</a>
 						<div class="w-px bg-base-300/80 my-2"></div>
-						<a class="px-4 py-6 hover:bg-base-200/60" href="/portfolio">Portfolio</a>
+						<a class="px-4 py-6 hover:bg-base-200/60" href="/portfolio">Portefølje</a>
 						<div class="w-px bg-base-300/80 my-2"></div>
-						<a class="px-4 py-6 hover:bg-base-200/60" href="/insights">Insights</a>
+						<a class="px-4 py-6 hover:bg-base-200/60" href="/insights">Indsigter</a>
 					{/if}
 				</div>
 				<!-- Spacer -->
@@ -32,9 +32,9 @@
 				<!-- Right section: login area with blue background -->
 				<div class="flex items-stretch">
 					{#if data.authed}
-						<a class="px-6 py-6 bg-primary text-primary-content hover:opacity-90" href="/logout" data-sveltekit-preload-data="off">Logout</a>
+						<a class="px-6 py-6 bg-primary text-primary-content hover:opacity-90" href="/logout" data-sveltekit-preload-data="off">Log ud</a>
 					{:else}
-						<a class="px-6 py-6 bg-primary text-primary-content hover:opacity-90" href="/login">Login</a>
+						<a class="px-6 py-6 bg-primary text-primary-content hover:opacity-90" href="/login">Log ind</a>
 					{/if}
 				</div>
 			</div>
@@ -47,7 +47,7 @@
 
 	<footer class="footer sm:footer-horizontal footer-center bg-base-300/70 text-base-content p-4">
 		<aside>
-			<p>Copyright © {new Date().getFullYear()} - IXBRL VSME Reader</p>
+			<p>Copyright © {new Date().getFullYear()} - IXBRL VSME Læser</p>
 		</aside>
 	</footer>
 </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds per-user sequential report numbers, flexible report upload with company fallback, a new insights API and cleanup endpoints, and updates the UI (incl. Danish localization) to consume them.
> 
> - **Data Model & Migrations**
>   - Add `Report.user_report_number` with migration populating sequential numbers per user; `__str__` now displays this number.
> - **Backend**:
>   - **Uploads**: Refactor `ReportUploadSerializer` (non-model) to accept optional `company`/`reporting_year`, add `company_name` fallback, auto-create/lookup companies, set default year, and assign next `user_report_number`.
>   - **Signals**: New handlers to recompute `VsmeRegister` on report/user delete and renumber remaining user reports.
>   - **Insights**: Add `GET /api/insights/aggregated/` returning per-user portfolio aggregates and quality metrics.
>   - **Register Maintenance**: Add `POST /api/vsme-register/cleanup-user/` to recompute entries for current user.
>   - **Utilities**: Add `extract_reporting_year_from_period` and a stub `quick_extract_metadata_from_file`.
>   - Wire signals via `ApiConfig.ready()`.
> - **API/Serializers**:
>   - Include `user_report_number` in `ReportListSerializer` and `ReportDetailSerializer`.
> - **Frontend (Svelte)**:
>   - Revamp Insights page to consume `insights/aggregated` with trend charts and distribution; portfolio/report pages show `user_report_number` and localized labels; submission flow simplified to file + optional company name; broad Danish localization.
> - **Deps**:
>   - Add `@sveltejs/adapter-node` and Rollup plugins in `package-lock.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c0f14eef066775ef3fc5f65520d8ae4eeb89522. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->